### PR TITLE
Blendshape support + bug fixes.

### DIFF
--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -320,9 +320,9 @@ namespace GLTF.Extensions
 			return quat;
 		}
 
-		public static Dictionary<string, T> ReadAsDictionary<T>(this JsonReader reader, Func<T> deserializerFunc)
+		public static Dictionary<string, T> ReadAsDictionary<T>(this JsonReader reader, Func<T> deserializerFunc, bool skipStartObjectRead = false)
 		{
-			if (reader.Read() && reader.TokenType != JsonToken.StartObject)
+			if (!skipStartObjectRead && reader.Read() && reader.TokenType != JsonToken.StartObject)
 			{
 				throw new Exception(string.Format("Dictionary must be an object at: {0}", reader.Path));
 			}

--- a/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
+++ b/GLTFSerialization/GLTFSerialization/Extensions/GLTFJsonExtensions.cs
@@ -193,7 +193,7 @@ namespace GLTF.Extensions
 			return color;
 		}
 
-		public static Color ReadAsRGBColor(this JsonReader reader)
+		public static Color ReadAsRGBColor(this JsonReader reader, bool skipIfAlpha = false)
 		{
 			if (reader.Read() && reader.TokenType != JsonToken.StartArray)
 			{
@@ -208,7 +208,13 @@ namespace GLTF.Extensions
 				A = 1.0f
 			};
 
-			if (reader.Read() && reader.TokenType != JsonToken.EndArray)
+			if (reader.Read() && skipIfAlpha &&
+				(reader.TokenType == JsonToken.Integer || reader.TokenType == JsonToken.Float))
+			{
+				reader.Read();
+			}
+
+			while (reader.TokenType != JsonToken.EndArray)
 			{
 				throw new Exception(string.Format("Invalid color value at: {0}", reader.Path));
 			}

--- a/GLTFSerialization/GLTFSerialization/Schema/GLTFMaterial.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/GLTFMaterial.cs
@@ -144,7 +144,7 @@ namespace GLTF.Schema
 						material.EmissiveTexture = TextureInfo.Deserialize(root, reader);
 						break;
 					case "emissiveFactor":
-						material.EmissiveFactor = reader.ReadAsRGBColor();
+						material.EmissiveFactor = reader.ReadAsRGBColor(true);
 						break;
 					case "alphaMode":
 						material.AlphaMode = reader.ReadStringEnum<AlphaMode>();

--- a/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
@@ -204,11 +204,11 @@ namespace GLTF.Schema
 					case "targets":
 						primitive.Targets = reader.ReadList(() =>
 						{
-							var dict = new Dictionary<string, AccessorId>();
-							while (reader.Read() && reader.TokenType == JsonToken.PropertyName) {
-								dict.Add(reader.Value.ToString(), AccessorId.Deserialize(root, reader));
-							}
-							return dict;
+							return reader.ReadAsDictionary(() => new AccessorId
+							{
+									Id = reader.ReadAsInt32().Value,
+									Root = root
+							}, true);
 						});
 						break;
 					default:

--- a/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
+++ b/GLTFSerialization/GLTFSerialization/Schema/MeshPrimitive.cs
@@ -204,11 +204,11 @@ namespace GLTF.Schema
 					case "targets":
 						primitive.Targets = reader.ReadList(() =>
 						{
-							return reader.ReadAsDictionary(() => new AccessorId
-							{
-								Id = reader.ReadAsInt32().Value,
-								Root = root
-							});
+							var dict = new Dictionary<string, AccessorId>();
+							while (reader.Read() && reader.TokenType == JsonToken.PropertyName) {
+								dict.Add(reader.Value.ToString(), AccessorId.Deserialize(root, reader));
+							}
+							return dict;
 						});
 						break;
 					default:

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MeshCacheData.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/Cache/MeshCacheData.cs
@@ -8,10 +8,12 @@ namespace UnityGLTF.Cache
 	{
 		public Mesh LoadedMesh { get; set; }
 		public Dictionary<string, AttributeAccessor> MeshAttributes { get; set; }
+		public List<Dictionary<string, AttributeAccessor>> MeshTargets { get; set; }
 
 		public MeshCacheData()
 		{
 			MeshAttributes = new Dictionary<string, AttributeAccessor>();
+			MeshTargets = new List<Dictionary<string, AttributeAccessor>>();
 		}
 
 		/// <summary>

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -957,6 +957,7 @@ namespace UnityGLTF
 			nodeObj.transform.localPosition = position;
 			nodeObj.transform.localRotation = rotation;
 			nodeObj.transform.localScale = scale;
+			_assetCache.NodeCache[nodeIndex] = nodeObj;
 
 			if (node.Mesh != null)
 			{
@@ -982,7 +983,6 @@ namespace UnityGLTF
 			}
 
 			nodeObj.SetActive(true);
-			_assetCache.NodeCache[nodeIndex] = nodeObj;
 		}
 
 		private bool NeedsSkinnedMeshRenderer(MeshPrimitive primitive, Skin skin)

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1048,6 +1048,11 @@ namespace UnityGLTF
 				bindPoses[i] = gltfBindPoses[i].ToUnityMatrix4x4Convert();
 			}
 
+			if (_assetCache.NodeCache[skin.Skeleton.Id] == null)
+			{
+				yield return ConstructNode(_gltfRoot.Nodes[skin.Skeleton.Id], skin.Skeleton.Id);
+			}
+
 			renderer.rootBone = _assetCache.NodeCache[skin.Skeleton.Id].transform;
 			curMesh.bindposes = bindPoses;
 			renderer.bones = bones;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -1067,10 +1067,10 @@ namespace UnityGLTF
 			BoneWeight[] boneWeights = new BoneWeight[vertCount];
 			for (int i = 0; i < vertCount; i++)
 			{
-				boneWeights[i].boneIndex0 = (int)joints[i].x;
-				boneWeights[i].boneIndex1 = (int)joints[i].y;
-				boneWeights[i].boneIndex2 = (int)joints[i].z;
-				boneWeights[i].boneIndex3 = (int)joints[i].w;
+				if (weights[i].x != 0.0f) boneWeights[i].boneIndex0 = (int)joints[i].x;
+				if (weights[i].y != 0.0f) boneWeights[i].boneIndex1 = (int)joints[i].y;
+				if (weights[i].z != 0.0f) boneWeights[i].boneIndex2 = (int)joints[i].z;
+				if (weights[i].w != 0.0f) boneWeights[i].boneIndex3 = (int)joints[i].w;
 
 				boneWeights[i].weight0 = weights[i].x;
 				boneWeights[i].weight1 = weights[i].y;

--- a/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
+++ b/UnityGLTF/Assets/UnityGLTF/Scripts/GLTFSceneImporter.cs
@@ -618,9 +618,64 @@ namespace UnityGLTF
 				{
 					GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
 				}
-				
+
 				TransformAttributes(ref attributeAccessors);
 				_assetCache.MeshCache[meshID][primitiveIndex].MeshAttributes = attributeAccessors;
+
+				yield return ConstructMeshTargetAttributes(primitive, meshID, primitiveIndex);
+			}
+		}
+
+		protected virtual IEnumerator ConstructMeshTargetAttributes(MeshPrimitive primitive, int meshID, int primitiveIndex)
+		{
+			if (primitive.Targets != null)
+			{
+				int targetCount = primitive.Targets.Count;
+				for (int targetIndex = 0; targetIndex < targetCount; ++targetIndex)
+				{
+					var target = primitive.Targets[targetIndex];
+
+					var attributeAccessors = new Dictionary<string, AttributeAccessor>(target.Count + 1);
+					foreach (var attributePair in target)
+					{
+						BufferId bufferIdPair = attributePair.Value.Value.BufferView.Value.Buffer;
+						GLTFBuffer buffer = bufferIdPair.Value;
+						int bufferId = bufferIdPair.Id;
+
+						// on cache miss, load the buffer
+						if (_assetCache.BufferCache[bufferId] == null)
+						{
+							yield return ConstructBuffer(buffer, bufferId);
+						}
+
+						AttributeAccessor attributeAccessor = new AttributeAccessor
+						{
+							AccessorId = attributePair.Value,
+							Stream = _assetCache.BufferCache[bufferId].Stream,
+							Offset = _assetCache.BufferCache[bufferId].ChunkOffset
+						};
+
+						attributeAccessors[attributePair.Key] = attributeAccessor;
+					}
+
+					if (isMultithreaded)
+					{
+						Thread buildMeshAttributesThread = new Thread(() => GLTFHelpers.BuildMeshAttributes(ref attributeAccessors));
+						buildMeshAttributesThread.Priority = ThreadPriority.Highest;
+						buildMeshAttributesThread.Start();
+						while (!buildMeshAttributesThread.Join(Timeout))
+						{
+							yield return null;
+						}
+					}
+					else
+					{
+						GLTFHelpers.BuildMeshAttributes(ref attributeAccessors);
+					}
+
+					TransformAttributes(ref attributeAccessors);
+					_assetCache.MeshCache[meshID][primitiveIndex].MeshTargets.Add(attributeAccessors);
+				}
 			}
 		}
 
@@ -945,6 +1000,26 @@ namespace UnityGLTF
 			return primitive.Targets != null;
 		}
 
+		protected virtual IEnumerator SetupBlendShapes(int meshID, int primitiveIndex, MeshPrimitive primitive, List<double> weights, Mesh mesh)
+		{
+			var targets = _assetCache.MeshCache[meshID][primitiveIndex].MeshTargets;
+			int targetCount = targets.Count;
+			bool hasWeights = weights != null && weights.Count != 0;
+			for (int index = 0; index < targetCount; ++index)
+			{
+				Vector3[] vertices = primitive.Targets[index].ContainsKey(SemanticProperties.POSITION)
+					? targets[index][SemanticProperties.POSITION].AccessorContent.AsVertices.ToUnityVector3Raw()
+					: null;
+				Vector3[] normals = primitive.Targets[index].ContainsKey(SemanticProperties.NORMAL)
+					? targets[index][SemanticProperties.NORMAL].AccessorContent.AsNormals.ToUnityVector3Raw()
+					: null;
+
+				float weight = hasWeights ? (float)weights[index] : 0.0f;
+				mesh.AddBlendShapeFrame(index.ToString(), weight, vertices, normals, null);
+				yield return null;
+			}
+		}
+
 		protected virtual IEnumerator SetupBones(Skin skin, MeshPrimitive primitive, SkinnedMeshRenderer renderer, GameObject primitiveObj, Mesh curMesh)
 		{
 			var boneCount = skin.Joints.Count;
@@ -1045,9 +1120,10 @@ namespace UnityGLTF
 					var skinnedMeshRenderer = primitiveObj.AddComponent<SkinnedMeshRenderer>();
 					skinnedMeshRenderer.material = material;
 					skinnedMeshRenderer.quality = SkinQuality.Auto;
-					// TODO: add support for blend shapes/morph targets
-					//if (HasBlendShapes(primitive))
-					//	SetupBlendShapes(primitive);
+					if (HasBlendShapes(primitive))
+					{
+						yield return SetupBlendShapes(meshId, i, primitive, mesh.Weights, curMesh);
+					}
 					if (HasBones(skin))
 					{
 						yield return SetupBones(skin, primitive, skinnedMeshRenderer, primitiveObj, curMesh);


### PR DESCRIPTION
This PR mainly addresses adding blendshape support but also includes a few other fixes which needed attention to get our gltf assets loadings.

- `d5fb28b` & `8a61ce8` : Fixes issue #232 and partially fixes #176
- `e046bc5` & `84381cb`: Add blendshape support.
- `77d1328`: Allows loops within the scene graph.
- `bd6c21d`: Fixes #202
- `c888ac6`: Only set bones with weight so Unity does't complain about invalid bones.
- `deabffe`: Spec compliance regarding optional alpha in [material emissiveTexture spec](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.schema.json).

Example of simple morph test asset loaded and morphed with a blendshape weight:

<img width="410" alt="screen shot 2018-09-26 at 2 44 21 pm" src="https://user-images.githubusercontent.com/389826/46109102-e07ac000-c19c-11e8-8187-18649025c6ef.png">
